### PR TITLE
Fix produce

### DIFF
--- a/src/deep_blue/platform/logic/command.py
+++ b/src/deep_blue/platform/logic/command.py
@@ -173,7 +173,7 @@ class Produce(Command):
             return False
         for element in game.map_info.elements.values():
             if isinstance(element, Base) and element.team == team:
-                if element.metal < PROPERTY[self.kind]['health_max'] * METAL_PER_HEALTH:
+                if element.metal < int(PROPERTY[self.kind]['health_max'] * METAL_PER_HEALTH):
                     return False
         game.commands[team].append(self)
         self.team = team

--- a/src/deep_blue/platform/logic/command.py
+++ b/src/deep_blue/platform/logic/command.py
@@ -182,7 +182,10 @@ class Produce(Command):
     def result_event(self, game):
         for element in game.map_info.elements.values():
             if isinstance(element, Base) and element.team == self.team:
-                element.metal -= int(PROPERTY[self.kind]['health_max'] * METAL_PER_HEALTH)
+                metal_need = int(PROPERTY[self.kind]['health_max'] * METAL_PER_HEALTH)
+                if element.metal < metal_need:  # No enough metal
+                    return []
+                element.metal -= metal_need
                 break
         game.production_lists[self.team].append([self.kind, basic.PROPERTY[self.kind]['build_round']])
         return [event.AddProductionEntry(self.team, self.kind)]

--- a/src/deep_blue/platform/logic/command.py
+++ b/src/deep_blue/platform/logic/command.py
@@ -175,7 +175,6 @@ class Produce(Command):
             if isinstance(element, Base) and element.team == team:
                 if element.metal < PROPERTY[self.kind]['health_max'] * METAL_PER_HEALTH:
                     return False
-                break
         game.commands[team].append(self)
         self.team = team
         return True


### PR DESCRIPTION
Try to fix a bug that metals of base can become negative, when producing multiple units in one round.
(Happened in boom.battle)
